### PR TITLE
Freddie memory usage improvements

### DIFF
--- a/freddie/freddie.go
+++ b/freddie/freddie.go
@@ -25,7 +25,7 @@ import (
 const (
 	consumerTTL = 20
 	msgTTL      = 5
-	bufferSz    = 16384
+	bufferSz    = 1000
 )
 
 var (

--- a/freddie/freddie.go
+++ b/freddie/freddie.go
@@ -230,6 +230,7 @@ func (f *Freddie) handleSignalGet(ctx context.Context, w http.ResponseWriter, r 
 	span.SetAttributes(attribute.String("consumer.id", consumerID))
 
 	consumerChan := consumerTable.Add(consumerID)
+	defer func() { close(consumerChan) }()
 	defer consumerTable.Delete(consumerID)
 
 	// TODO: Matchmaking would happen here. (Just be selective about which consumers you broadcast
@@ -261,6 +262,7 @@ func (f *Freddie) handleSignalPost(ctx context.Context, w http.ResponseWriter, r
 	span.SetAttributes(attribute.String("request.id", reqID))
 
 	reqChan := signalTable.Add(reqID)
+	defer func() { close(reqChan) }()
 	defer signalTable.Delete(reqID)
 
 	r.ParseForm()


### PR DESCRIPTION
There are two changes here, only one of which really makes a difference (I think). First, I am explicitly calling `close()` on channels before they go out of scope, because I'm not 100% certain that when we delete the containing map entry we don't still have a reference to it somewhere else, which causes a memory leak. (Either way, closing the channel can't hurt.)

The second change is probably the more useful one: taking the user table channel buffer length down from 16,384 to 1,000. I think when the code was written it was assumed that this allocated 16k _bytes_ for the channel, but it actually allocates enough memory to store 16k _strings_. Assuming the size of a string pointer in Go is (64-bit length + 64-bit pointer) 128 bits, using 16k for the buffer length means that Freddie requires 256KiB of memory per connection. Dropping down to 1,000 puts it at 16KB per connection.


At any rate, these two changes mean that our Freddie instance goes from OOM-ing after trying to allocate >32GiB of memory to using ~8.5GiB to service 128k concurrent connections, so it's good enough for now.